### PR TITLE
Make PagingData.next optional

### DIFF
--- a/InstagramAPI/Sources/InstagramAPIModels.swift
+++ b/InstagramAPI/Sources/InstagramAPIModels.swift
@@ -53,7 +53,7 @@ public struct PagingData: Codable {
   
     public var cursors: CursorData
     
-    public var next: String
+    public var next: String?
 }
 
 public struct CursorData: Codable {


### PR DESCRIPTION
It may not be returned by the API and can cause decoder errors.

Also, if it's not returned, it means there is no "next page" for feed.